### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,9 +8,14 @@ on:
       - "*"
   pull_request:
 
+permissions: read-all
+
 jobs:
   docker:
     uses: Drakkar-Software/.github/.github/workflows/docker_workflow.yml@master
+    permissions:
+      contents: read
+      packages: write
     with:
       distribution_name: marketmaking
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
       - '*'
   pull_request:
 
+permissions: read-all
+
 jobs:
   lint:
     name: ${{ matrix.os }}${{ matrix.arch }} - Python ${{ matrix.version }} - lint


### PR DESCRIPTION
Thank you for sending your pull request. 
But first, have you included unit tests, and is your code PEP8 conformant? [More details](https://github.com/Drakkar-Software/OctoBot-Market-Making/blob/master/CONTRIBUTING.md)

## Summary
Add explicit least-privilege permissions to GitHub Actions workflows for improved security.

## Changelog

  - Add `permissions: read-all` at workflow level in `docker.yml` and `main.yml`
  - Add explicit job-level permissions to docker workflow job (`contents: read`, `packages: write`)

## What's new?

This PR implements explicit permission declarations in GitHub Actions workflows following security best practices. By default, GitHub Actions workflows have broad permissions, which poses a security risk. These changes:

1. Set a baseline of `read-all` at the workflow level to establish least-privilege access
2. Override with specific job-level permissions for the docker workflow job that requires `packages: write` to push Docker images while maintaining `contents: read` for repository access

This improves the security posture of the CI/CD pipeline by ensuring workflows only have the minimum permissions necessary to perform their intended tasks.

https://claude.ai/code/session_01W8aBTV6r7yGD3kccARKM5v